### PR TITLE
Improve instructions

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -391,8 +391,8 @@ const cmds = {
         )}   \\${c.greenBright("$$")}    \\${c.greenBright("$$")}   \n`
       );
       t3rm.writeln(
-        `Note: All t3rm.dev native packages start with ${c.yellowBright(
-          "dev.t3rm."
+        `Note: For compatibility we RECOMMEND the default bundle prefix ${c.yellowBright(
+          "dev.t3rm._PKG_"
         )}\n`
       );
 


### PR DESCRIPTION
As an open platform, users are free to change their namespace beyond `dev.t3rm.` However, no one has created this function just yet in the system, so we will still recommend users stick with the default unless they know what they're doing.